### PR TITLE
Make Kriminalamt only trigger on user_joined

### DIFF
--- a/kantek/plugins/autobahn/kriminalamt.py
+++ b/kantek/plugins/autobahn/kriminalamt.py
@@ -33,6 +33,8 @@ async def kriminalamt(event: ChatAction.Event) -> None:
     kriminalamt_tag = db_named_tags.get('kriminalamt')
     bancmd = db_named_tags.get('gbancmd', 'manual')
     delay = 1
+    if not event.user_joined:
+        return
     if not kriminalamt_tag or user.bot:
         return
     elif isinstance(kriminalamt_tag, int):


### PR DESCRIPTION
Currently Kriminalamt will fire on every Chat Action Event afaik. This can possibly lead to wrongful bans. My addition will check if the event is a user_joined event and will return if it is not.